### PR TITLE
feat: 增加SoundPlayer网络音频加载完成的回调消息

### DIFF
--- a/harmony/rn_sound_player/src/main/ets/RNSoundPlayerModule.ts
+++ b/harmony/rn_sound_player/src/main/ets/RNSoundPlayerModule.ts
@@ -78,6 +78,7 @@ export class RNSoundPlayerModule extends AnyThreadTurboModule {
           case 'prepared':
             Logger.info(TAG, 'RNSoundPlayer state prepared called');
             if (this.url) {
+              this.sendEvent(EVENT_FINISHED_LOADING, { "success": true });
               this.sendEvent(EVENT_FINISHED_LOADING_URL, { "success": true, "url": this.url });
             } else {
               this.sendMountFileSuccessEvents(this.name, this.type);


### PR DESCRIPTION

# Summary

feat: 增加SoundPlayer网络音频加载完成的回调消息

## Test Plan

<img width="286" height="618" alt="image" src="https://github.com/user-attachments/assets/8685bf8c-43a2-4608-a75b-271d904f4df9" />


## Checklist

<!-- 检查项, 请自行排查并打钩, 通过: [X] -->

- [X] 已经在真机设备或模拟器上测试通过
- [ ] 已经与 Android 或 iOS 平台做过效果/功能对比
- [ ] 已经添加了对应 API 的测试用例（如需要）
- [ ] 已经更新了文档（如需要）
- [ ] 更新了 JS/TS 代码 (如有)

